### PR TITLE
Fix/dataview parser option set

### DIFF
--- a/common/changes/@visactor/vdataset/fix-dataview-parser-option-set_2023-09-04-11-26.json
+++ b/common/changes/@visactor/vdataset/fix-dataview-parser-option-set_2023-09-04-11-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: fix bug of dataView parse option when the type is undefiend\n\n",
+      "type": "none",
+      "packageName": "@visactor/vdataset"
+    }
+  ],
+  "packageName": "@visactor/vdataset",
+  "email": "lixuef1313@163.com"
+}

--- a/packages/vdataset/src/data-view.ts
+++ b/packages/vdataset/src/data-view.ts
@@ -94,10 +94,7 @@ export class DataView {
     del: any;
   };
 
-  constructor(
-    public dataSet: DataSet,
-    public options?: IDataViewOptions
-  ) {
+  constructor(public dataSet: DataSet, public options?: IDataViewOptions) {
     let name;
     if (options?.name) {
       name = options.name;
@@ -127,9 +124,9 @@ export class DataView {
     if (emit) {
       this.target.emit('beforeParse', []);
     }
+    options && (this.parseOption = options);
     const cloneData = this.cloneParseData(data, options);
     if (options?.type) {
-      this.parseOption = options;
       options = cloneDeep(options);
       // 默认bytejson
       const parserFn = this.dataSet.getParser(options.type) ?? this.dataSet.getParser('bytejson');


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/Vutil/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
