### PR TITLE
Fix/container size when display none

### DIFF
--- a/common/changes/@visactor/vutils/fix-container-size-when-display-none_2023-12-22-07-44.json
+++ b/common/changes/@visactor/vutils/fix-container-size-when-display-none_2023-12-22-07-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: fix bug of `getContainerSize()` when the container has `display: none`\n\n",
+      "type": "none",
+      "packageName": "@visactor/vutils"
+    }
+  ],
+  "packageName": "@visactor/vutils",
+  "email": "dingling112@gmail.com"
+}

--- a/packages/vutils/src/dom.ts
+++ b/packages/vutils/src/dom.ts
@@ -19,17 +19,23 @@ export function getContainerSize(el: HTMLElement | null, defaultWidth: number = 
   // clientWidth/clientHeight: 默认整数，会向上取整，导致canvas > container
   // getBoundingClientRect：默认小数，但是在container上有css类似 transform: scale(0.5)时，获取结果不对
   // getComputedStyle：默认小数，获取最终结果，但是会包含padding；
-  const computedWidth =
-    parseFloat(style.width) - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight) || el.clientWidth - 1;
 
-  const computedHeight =
-    parseFloat(style.height) - parseFloat(style.paddingTop) - parseFloat(style.paddingBottom) || el.clientHeight - 1;
+  if (/^(\d*\.?\d+)(px)$/.exec(style.width)) {
+    // 当dom元素的 display: 'none' 的时候，获取到的宽高会变成原始的样式配置，而不是计算后的像素值
+    const computedWidth =
+      parseFloat(style.width) - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight) || el.clientWidth - 1;
 
-  // 理论上不用向下取整，目前没加。
-  return {
-    width: computedWidth <= 0 ? defaultWidth : computedWidth,
-    height: computedHeight <= 0 ? defaultHeight : computedHeight
-  };
+    const computedHeight =
+      parseFloat(style.height) - parseFloat(style.paddingTop) - parseFloat(style.paddingBottom) || el.clientHeight - 1;
+
+    // 理论上不用向下取整，目前没加。
+    return {
+      width: computedWidth <= 0 ? defaultWidth : computedWidth,
+      height: computedHeight <= 0 ? defaultHeight : computedHeight
+    };
+  }
+
+  return { width: defaultWidth, height: defaultHeight };
 }
 
 /**


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/Vutil/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
