### PR TITLE
fix: fix the bug of log-scale ticks

### DIFF
--- a/common/changes/@visactor/vscale/fix-log-ticks_2023-12-28-08-48.json
+++ b/common/changes/@visactor/vscale/fix-log-ticks_2023-12-28-08-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: fix the bug of log-scale ticks\n\n",
+      "type": "none",
+      "packageName": "@visactor/vscale"
+    }
+  ],
+  "packageName": "@visactor/vscale",
+  "email": "dingling112@gmail.com"
+}

--- a/packages/vscale/__tests__/log.test.ts
+++ b/packages/vscale/__tests__/log.test.ts
@@ -155,7 +155,7 @@ it('log.nice() nices the domain, extending it to powers of ten', () => {
 
 it('log.nice() works on degenerate domains', () => {
   const x = new LogScale().domain([0, 0]).nice();
-  expect(x.domain()).toEqual([0, 0]);
+  expect(x.domain()).toEqual([1e-16, 1e-15]);
   x.domain([0.5, 0.5]).nice();
   expect(x.domain()).toEqual([0.1, 1]);
 });
@@ -164,7 +164,7 @@ it('log.nice() on a polylog domain only affects the extent', () => {
   const x = new LogScale().domain([1.1, 1.5, 10.9]).nice();
   expect(x.domain()).toEqual([1, 1.5, 11]);
   x.domain([-124, -1.5, -0]).nice();
-  expect(x.domain()).toEqual([-1000, -1.5, -0]);
+  expect(x.domain()).toEqual([-1000, -1.5, -1e-16]);
 });
 
 it('log.nice() works on large domains with large or small base', () => {
@@ -369,7 +369,7 @@ function round(x: number) {
 it('log scale dont throw error when domain contain 0', () => {
   const scale = new LogScale().domain([0, 1000]).range([0, 10000]);
 
-  expect(scale.scale(100)).toBeCloseTo(9333.333333333334);
+  expect(scale.scale(100)).toBeCloseTo(9463.909295551413);
   expect(scale.scale(0)).toBeCloseTo(0);
   expect(scale.scale(1000)).toBeCloseTo(10000);
   expect(scale.ticks(5)).toEqual([0, 1, 1000]);
@@ -377,7 +377,7 @@ it('log scale dont throw error when domain contain 0', () => {
 
 it('log scale dont throw error when domain contain 0 and negative value', () => {
   const scale = new LogScale().domain([-1000, 0]).range([0, 10000]);
-  expect(scale.scale(-160)).toBeCloseTo(530.5866782293836);
+  expect(scale.scale(-160)).toBeCloseTo(426.6638791545382);
   expect(scale.scale(0)).toBeCloseTo(10000);
   expect(scale.scale(-1000)).toBeCloseTo(0);
   expect(scale.ticks(5)).toEqual([-1000, -1, -0]);

--- a/packages/vscale/src/log-scale.ts
+++ b/packages/vscale/src/log-scale.ts
@@ -13,13 +13,13 @@ function reflect(f: (x: number) => number) {
   return (x: number) => -f(-x);
 }
 
-function limitPositiveZero(min: number = 1e-12) {
+function limitPositiveZero(min: number = Number.EPSILON) {
   return (x: number) => {
     return Math.max(x, min);
   };
 }
 
-function limitNegativeZero(min: number = 1e-12) {
+function limitNegativeZero(min: number = Number.EPSILON) {
   return (x: number) => {
     return Math.min(x, -min);
   };
@@ -118,8 +118,8 @@ export class LogScale extends ContinuousScale {
 
   d3Ticks(count: number = 10) {
     const d = this.domain();
-    let u = d[0];
-    let v = d[d.length - 1];
+    let u = this._limit(d[0]);
+    let v = this._limit(d[d.length - 1]);
     const r = v < u;
 
     if (r) {
@@ -232,8 +232,8 @@ export class LogScale extends ContinuousScale {
 
     if (niceType) {
       const niceDomain = nice(originalDomain.slice(), {
-        floor: (x: number) => this._pows(Math.floor(this._logs(x))),
-        ceil: (x: number) => Math.ceil(x)
+        floor: (x: number) => this._pows(Math.floor(this._logs(this._limit(x)))),
+        ceil: (x: number) => (Math.abs(x) >= 1 ? Math.ceil(x) : this._pows(Math.ceil(this._logs(this._limit(x)))))
       });
 
       if (niceType === 'min') {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/Vutil/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
