### PR TITLE
fix: fix clamp of comtinuous scale

### DIFF
--- a/packages/vscale/__tests__/clamp.test.ts
+++ b/packages/vscale/__tests__/clamp.test.ts
@@ -1,0 +1,15 @@
+import { LinearScale } from '../src/linear-scale';
+
+test('linear(x) will not ignores extra range values if the domain is smaller than the range', function () {
+  const scale = new LinearScale();
+
+  scale.clamp(true).domain([-10, 10]).range([100, 200]);
+  expect(scale.scale(0)).toBe(150);
+  expect(scale.scale(-50)).toBe(100);
+  expect(scale.scale(50)).toBe(200);
+
+  scale.domain([-100, 100]);
+  expect(scale.scale(0)).toBe(150);
+  expect(scale.scale(-50)).toBe(125);
+  expect(scale.scale(50)).toBe(175);
+});

--- a/packages/vscale/src/continuous-scale.ts
+++ b/packages/vscale/src/continuous-scale.ts
@@ -33,6 +33,7 @@ export class ContinuousScale extends BaseScale implements IContinuousScale {
   protected _domainValidator?: (val: number) => boolean;
 
   _clamp?: (x: number) => number;
+  _autoClamp?: boolean;
 
   constructor(transformer: TransformType = identity, untransformer: TransformType = identity) {
     super();
@@ -154,7 +155,7 @@ export class ContinuousScale extends BaseScale implements IContinuousScale {
       n = rangeLength;
     }
 
-    if (this._clamp === undefined) {
+    if (this._autoClamp) {
       this._clamp = clamper(domain[0], domain[n - 1]);
     }
     this._piecewise = n > 2 ? polymap : bimap;
@@ -172,8 +173,10 @@ export class ContinuousScale extends BaseScale implements IContinuousScale {
       return this._clamp !== identity;
     }
     if (f) {
+      this._autoClamp = false;
       this._clamp = f;
     } else {
+      this._autoClamp = !!_;
       this._clamp = _ ? undefined : identity;
     }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/Vutil/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
