### PR TITLE
Feat/support index in ordinal scale

### DIFF
--- a/common/changes/@visactor/vscale/feat-support-index-in-ordinal-scale_2024-02-26-08-17.json
+++ b/common/changes/@visactor/vscale/feat-support-index-in-ordinal-scale_2024-02-26-08-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "feat: support the index api to get the index of value in ordianlScale.domain\n\n",
+      "type": "none",
+      "packageName": "@visactor/vscale"
+    }
+  ],
+  "packageName": "@visactor/vscale",
+  "email": "lixuef1313@163.com"
+}

--- a/packages/vscale/__tests__/ordinal.test.ts
+++ b/packages/vscale/__tests__/ordinal.test.ts
@@ -224,3 +224,20 @@ test('ordinal.specified could set & get the special map and work well', function
   expect(s.scale('a')).toEqual('white');
   expect(s.scale('b')).toEqual(null);
 });
+
+test('ordinal.index() work well', function () {
+  const s = new OrdinalScale().domain(['a', 'b']).range(['white', 'black']).specified({ a: 'red' });
+  expect(s.index('a')).toEqual(1);
+  expect(s.index('b')).toEqual(2);
+  expect(s.index('c')).toEqual(-1);
+
+  const s1 = new OrdinalScale().domain([0, 1]).range(['white', 'black']);
+  expect(s1.index(0)).toEqual(1);
+  expect(s1.index('0')).toEqual(1);
+  expect(s1.index(1)).toEqual(2);
+  expect(s1.index('')).toEqual(-1);
+
+  const s2 = new OrdinalScale().range(['white', 'black']);
+  expect(s2.index('')).toEqual(-1);
+  expect(s2.index(0)).toEqual(-1);
+});

--- a/packages/vscale/src/interface.ts
+++ b/packages/vscale/src/interface.ts
@@ -74,6 +74,12 @@ export interface IBaseScale {
 
 export interface IOrdinalScale extends IBaseScale {
   specified: (_?: Record<string, unknown>) => this | Record<string, unknown>;
+  /**
+   * 获取domain中值的序号, 历史原因序号从 1 开始
+   * @param x 输入值
+   * @returns 序号，如果不存在，返回 -1
+   */
+  index: (x: any) => number;
 }
 
 export interface IBandLikeScale extends IOrdinalScale, IRangeFactor {

--- a/packages/vscale/src/ordinal-scale.ts
+++ b/packages/vscale/src/ordinal-scale.ts
@@ -1,11 +1,11 @@
 import { ScaleEnum } from './type';
-import type { DiscreteScaleType, IBaseScale } from './interface';
+import type { DiscreteScaleType, IOrdinalScale } from './interface';
 import { BaseScale } from './base-scale';
 import { isValid } from '@visactor/vutils';
 
 export const implicit = Symbol('implicit');
 
-export class OrdinalScale extends BaseScale implements IBaseScale {
+export class OrdinalScale extends BaseScale implements IOrdinalScale {
   readonly type: DiscreteScaleType = ScaleEnum.Ordinal;
   protected _index: Map<string, number>;
   protected _domain: Array<number>;
@@ -38,8 +38,11 @@ export class OrdinalScale extends BaseScale implements IBaseScale {
   }
 
   // TODO checkPoint
-  clone(): IBaseScale {
-    return new OrdinalScale().domain(this._domain).range(this._ordinalRange).unknown(this._unknown);
+  clone(): IOrdinalScale {
+    const s = new OrdinalScale().domain(this._domain).range(this._ordinalRange).unknown(this._unknown);
+    // _specified 为空时，不会返回this
+    this._specified && s.specified(this._specified);
+    return s;
   }
 
   calculateVisibleDomain(range: any[]) {
@@ -111,5 +114,12 @@ export class OrdinalScale extends BaseScale implements IBaseScale {
 
     this._ordinalRange = nextRange;
     return this;
+  }
+
+  index(x: any): number {
+    if (!this._index) {
+      return -1;
+    }
+    return this._index.get(`${x}`) ?? -1;
   }
 }


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/Vutil/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [X] New feature
- [ ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
