### PR TITLE
Fix/range factor of band scale

### DIFF
--- a/common/changes/@visactor/vscale/fix-range-factor-of-band-scale_2025-02-06-11-06.json
+++ b/common/changes/@visactor/vscale/fix-range-factor-of-band-scale_2025-02-06-11-06.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: fix rangeFactor when fix band width\n\n",
+      "type": "none",
+      "packageName": "@visactor/vscale"
+    }
+  ],
+  "packageName": "@visactor/vscale",
+  "email": "dingling112@gmail.com"
+}

--- a/packages/vscale/src/band-scale.ts
+++ b/packages/vscale/src/band-scale.ts
@@ -151,16 +151,6 @@ export class BandScale extends OrdinalScale implements IBandLikeScale {
         Math.sign(range[1] - range[0]);
       const rangeFactorSize = Math.min((range[1] - range[0]) / wholeLength, 1);
       if (isValid(this._rangeFactorStart) && isValid(this._rangeFactorEnd)) {
-        if (wholeLength > 0) {
-          const r0 = range[0] - wholeLength * this._rangeFactorStart;
-          const r1 = r0 + wholeLength;
-          this._wholeRange = [r0, r1];
-        } else {
-          const r1 = range[1] + wholeLength * (1 - this._rangeFactorEnd);
-          const r0 = r1 - wholeLength;
-          this._wholeRange = [r0, r1];
-        }
-
         const canAlignStart = this._rangeFactorStart + rangeFactorSize <= 1;
         const canAlignEnd = this._rangeFactorEnd - rangeFactorSize >= 0;
 
@@ -189,6 +179,16 @@ export class BandScale extends OrdinalScale implements IBandLikeScale {
               this._rangeFactorEnd = 1;
             }
           }
+        }
+
+        if (wholeLength > 0) {
+          const r0 = range[0] - wholeLength * this._rangeFactorStart;
+          const r1 = r0 + wholeLength;
+          this._wholeRange = [r0, r1];
+        } else {
+          const r1 = range[1] + wholeLength * (1 - this._rangeFactorEnd);
+          const r0 = r1 - wholeLength;
+          this._wholeRange = [r0, r1];
         }
       } else {
         this._rangeFactorStart = 0;


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/Vutil/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
