### PR TITLE
Fix: linear scale clone

### DIFF
--- a/common/changes/@visactor/vscale/fix-linear-scale-clone_2025-04-09-06-59.json
+++ b/common/changes/@visactor/vscale/fix-linear-scale-clone_2025-04-09-06-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vscale",
+      "comment": " fix: linear scale clone get incorrect domain",
+      "type": "none"
+    }
+  ],
+  "packageName": "@visactor/vscale"
+}

--- a/packages/vscale/__tests__/linear.test.ts
+++ b/packages/vscale/__tests__/linear.test.ts
@@ -848,3 +848,10 @@ test('linear.customTicks with wilkinson in interval option', async () => {
     })
   ).toStrictEqual([0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]);
 });
+
+test('linear.clone should not drop nice options', async () => {
+  const s = new LinearScale().domain([0, 58]).range([0, 531]).nice(5);
+  const s1 = s.clone();
+  expect(s1.domain()).toStrictEqual(s.domain());
+  expect(s1.range()).toStrictEqual(s.range());
+});

--- a/packages/vscale/src/linear-scale.ts
+++ b/packages/vscale/src/linear-scale.ts
@@ -13,12 +13,19 @@ export class LinearScale extends ContinuousScale {
   readonly type: ContinuousScaleType = ScaleEnum.Linear;
 
   clone(): LinearScale {
-    return new LinearScale()
+    const scale = new LinearScale();
+    scale
       .domain(this._domain, true)
       .range(this._range, true)
       .unknown(this._unknown)
       .clamp(this.clamp(), null, true)
       .interpolate(this._interpolate) as LinearScale;
+    if (this._niceType) {
+      scale._niceType = this._niceType;
+      scale._domainValidator = this._domainValidator;
+      scale._niceDomain = this._niceDomain?.slice();
+    }
+    return scale;
   }
 
   tickFormat() {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/Vutil/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Chore
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
